### PR TITLE
Fix for rounding issues.

### DIFF
--- a/moment-msdate.js
+++ b/moment-msdate.js
@@ -9,9 +9,9 @@
 	 * @returns moment
 	 */
 	moment.fromOADate = function(msDate) {
-		var jO = new Date( ((msDate - 25569) * 86400000) );
+		var jO = new Date( ((msDate - 25569) * 86400000) + (msDate >= 0.0 ? 0.5 : -0.5) ); 
 		var tz = jO.getTimezoneOffset();
-		var jO = new Date( ( (msDate-25569 + (tz / (60*24) ) ) * 86400000) );
+		var jO = new Date( ( (msDate-25569 + (tz / (60*24) ) ) * 86400000) + (msDate >= 0.0 ? 0.5 : -0.5) );
 		return moment(jO);
 	};
 

--- a/test/test.js
+++ b/test/test.js
@@ -9,13 +9,19 @@ lint(['./*.js', './test/*.js']);
 describe('moment-msdate', function() {
 	it('should parse an OLE Automation date int', function(done) {
 		var date = moment.fromOADate(41493);
-		assert.equal(date.toString(), 'Wed Aug 07 2013 00:00:00 GMT-0600');
+		assert.equal(date.toString().search('Wed Aug 07 2013 00:00:00'), 0);
 		done();
 	});
 
 	it('should parse an OLE Automation date double', function(done) {
 		var date = moment.fromOADate(41493.706892280097000);
-		assert.equal(date.toString(), 'Wed Aug 07 2013 16:57:55 GMT-0600');
+		assert.equal(date.toString().search('Wed Aug 07 2013 16:57:55'), 0);
+		done();
+	});
+
+	it('should handle rounding quirks', function(done) {
+		var date = moment.fromOADate(42681.501388888886);
+		assert.equal(date.toString().search('Mon Nov 07 2016 12:02:00'), 0);
 		done();
 	});
 


### PR DESCRIPTION
Matches implementation in System.DateTime.DoubleDateToTicks assembly.

There was a slight rounding error where you need to either add or subtract 0.5 to the milliseconds since windows epoch. This causes some dates to be out by a millisecond which can ultimately change the date.

Also modified the tests so the run regardless of the system timezone.