### PR TITLE
fixed issues with webpack build by using similar loading method from …

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,10 @@
 		}],
 		"comma-dangle": [2, "never"],
 		"no-underscore-dangle": 0,
-		"no-empty-function": 1
+		"no-empty-function": 1,
+		"no-param-reassign": 0
+	},
+	"env":{
+		"amd": true
 	}
 }

--- a/moment-msdate.js
+++ b/moment-msdate.js
@@ -1,4 +1,4 @@
-(function (root, factory) {
+(function(root, factory) {
 
 	'use strict';
 
@@ -10,7 +10,7 @@
 		factory(root.moment);
 	}
 
-}(this, function (moment) {
+}(this, (moment) => {
 
 	/**
 	* Constants
@@ -26,8 +26,8 @@
 	 * @param offsetToUtcInMinutes An offset from the msDate to UTC. If not supplied the offset from the system timezone will be used.
 	 * @returns moment
 	 */
-	moment.fromOADate = function (msDate, offsetToUtcInMinutes) {
-		var jO = new Date(((msDate - MS_DAY_OFFSET) * DAY_MILLISECONDS) + (msDate >= 0.0 ? 0.5 : -0.5));
+	moment.fromOADate = function(msDate, offsetToUtcInMinutes) {
+		let jO = new Date(((msDate - MS_DAY_OFFSET) * DAY_MILLISECONDS) + (msDate >= 0.0 ? 0.5 : -0.5));
 		const tz = isNaN(parseInt(offsetToUtcInMinutes, 10)) ? jO.getTimezoneOffset() : offsetToUtcInMinutes;
 		jO = new Date((((msDate - MS_DAY_OFFSET) + (tz / (60 * 24))) * DAY_MILLISECONDS) + (msDate >= 0.0 ? 0.5 : -0.5));
 		return moment(jO);
@@ -39,7 +39,7 @@
 	 * @param jsDate A JavaScript date object to convert to OA Date. Defaults to existing moment instance or new Date
 	 * @returns Floating-point number, e.g., 41502.558798240745
 	 */
-	moment.fn.toOADate = function (jsDateInput) {
+	moment.fn.toOADate = function(jsDateInput) {
 		const jsDate = jsDateInput || this._d || new Date();
 		const timezoneOffset = jsDate.getTimezoneOffset() / (60 * 24);
 		const msDateObj = (jsDate.getTime() / DAY_MILLISECONDS) + (MS_DAY_OFFSET - timezoneOffset);
@@ -54,7 +54,7 @@
 	* Converts an OLE Automation date to a moment (baking in a timezone if one is supplied)
 	* Returns a UTC Moment object instance
 	*/
-	moment.fromOADateWithZone = function (msDate, timeZone) {
+	moment.fromOADateWithZone = function(msDate, timeZone) {
 		const jsTicks = (msDate - MS_DAY_OFFSET) * DAY_MILLISECONDS;
 		const offset = moment.tz(timeZone).utcOffset() * MINUTE_MILLISECONDS;
 		if (timeZone) {
@@ -67,7 +67,7 @@
 	* Converts a moment (with timezone) to an OLE Automation date in UTC
 	* Returns an OLE Automation date in the form of a double
 	*/
-	moment.fn.toOADateWithZone = function () {
+	moment.fn.toOADateWithZone = function() {
 		const nMsDate = (this.valueOf() / DAY_MILLISECONDS) + MS_DAY_OFFSET;
 		return nMsDate;
 	};

--- a/moment-msdate.js
+++ b/moment-msdate.js
@@ -1,6 +1,16 @@
-'use strict';
+(function (root, factory) {
 
-(function() {
+	'use strict';
+
+	if (typeof define === 'function' && define.amd) {
+		define(['moment'], factory);
+	} else if (typeof module === 'object' && module.exports) {
+		module.exports = factory(require('moment'));
+	} else {
+		factory(root.moment);
+	}
+
+}(this, function (moment) {
 
 	/**
 	* Constants
@@ -9,8 +19,6 @@
 	const MINUTE_MILLISECONDS = 60000;
 	const MS_DAY_OFFSET = 25569;
 
-	const moment = (typeof require !== 'undefined' && require !== null) && !require.amd ? require('moment-timezone') : this.moment;
-
 	/**
 	 * @description To JavaScript date from OLE Automation date
 	 *
@@ -18,7 +26,7 @@
 	 * @param offsetToUtcInMinutes An offset from the msDate to UTC. If not supplied the offset from the system timezone will be used.
 	 * @returns moment
 	 */
-	moment.fromOADate = function(msDate, offsetToUtcInMinutes) {
+	moment.fromOADate = function (msDate, offsetToUtcInMinutes) {
 		let jO = new Date(((msDate - MS_DAY_OFFSET) * DAY_MILLISECONDS) + (msDate >= 0.0 ? 0.5 : -0.5));
 		const tz = isNaN(parseInt(offsetToUtcInMinutes, 10)) ? jO.getTimezoneOffset() : offsetToUtcInMinutes;
 		jO = new Date((((msDate - MS_DAY_OFFSET) + (tz / (60 * 24))) * DAY_MILLISECONDS) + (msDate >= 0.0 ? 0.5 : -0.5));
@@ -31,7 +39,7 @@
 	 * @param jsDate A JavaScript date object to convert to OA Date. Defaults to existing moment instance or new Date
 	 * @returns Floating-point number, e.g., 41502.558798240745
 	 */
-	moment.fn.toOADate = function(jsDateInput) {
+	moment.fn.toOADate = function (jsDateInput) {
 		const jsDate = jsDateInput || this._d || new Date();
 		const timezoneOffset = jsDate.getTimezoneOffset() / (60 * 24);
 		const msDateObj = (jsDate.getTime() / DAY_MILLISECONDS) + (MS_DAY_OFFSET - timezoneOffset);
@@ -46,7 +54,7 @@
 	* Converts an OLE Automation date to a moment (baking in a timezone if one is supplied)
 	* Returns a UTC Moment object instance
 	*/
-	moment.fromOADateWithZone = function(msDate, timeZone) {
+	moment.fromOADateWithZone = function (msDate, timeZone) {
 		const jsTicks = (msDate - MS_DAY_OFFSET) * DAY_MILLISECONDS;
 		const offset = moment.tz(timeZone).utcOffset() * MINUTE_MILLISECONDS;
 		if (timeZone) {
@@ -59,7 +67,7 @@
 	* Converts a moment (with timezone) to an OLE Automation date in UTC
 	* Returns an OLE Automation date in the form of a double
 	*/
-	moment.fn.toOADateWithZone = function() {
+	moment.fn.toOADateWithZone = function () {
 		const nMsDate = (this.valueOf() / DAY_MILLISECONDS) + MS_DAY_OFFSET;
 		return nMsDate;
 	};
@@ -68,4 +76,4 @@
 		module.exports = moment;
 	}
 
-}).call(this);
+}));

--- a/moment-msdate.js
+++ b/moment-msdate.js
@@ -27,7 +27,7 @@
 	 * @returns moment
 	 */
 	moment.fromOADate = function (msDate, offsetToUtcInMinutes) {
-		let jO = new Date(((msDate - MS_DAY_OFFSET) * DAY_MILLISECONDS) + (msDate >= 0.0 ? 0.5 : -0.5));
+		var jO = new Date(((msDate - MS_DAY_OFFSET) * DAY_MILLISECONDS) + (msDate >= 0.0 ? 0.5 : -0.5));
 		const tz = isNaN(parseInt(offsetToUtcInMinutes, 10)) ? jO.getTimezoneOffset() : offsetToUtcInMinutes;
 		jO = new Date((((msDate - MS_DAY_OFFSET) + (tz / (60 * 24))) * DAY_MILLISECONDS) + (msDate >= 0.0 ? 0.5 : -0.5));
 		return moment(jO);


### PR DESCRIPTION
as we had discussed earlier, followed the example from moment-timezone to load moment-aodate. I have tested this and it builds in webpack.

Fixes:
WARNING in ./~/moment-msdate/moment-msdate.js
22:51-58 Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
    at CommonJsRequireContextDependency.getWarnings (C:\Projects\MerrillLynch\IRT\node_modules\webpack\lib\dependencies\CommonJsRequireContextDe
pendency.js:27:4)
    at Compilation.reportDependencyErrorsAndWarnings (C:\Projects\MerrillLynch\IRT\node_modules\webpack\lib\Compilation.js:663:24)
    at Compilation.finish (C:\Projects\MerrillLynch\IRT\node_modules\webpack\lib\Compilation.js:526:9)
    at C:\Projects\MerrillLynch\IRT\node_modules\webpack\lib\Compiler.js:472:16
    at C:\Projects\MerrillLynch\IRT\node_modules\tapable\lib\Tapable.js:225:11
    at _addModuleChain (C:\Projects\MerrillLynch\IRT\node_modules\webpack\lib\Compilation.js:472:11)
    at processModuleDependencies.err (C:\Projects\MerrillLynch\IRT\node_modules\webpack\lib\Compilation.js:443:13)
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)