### PR TITLE
Remove strict null check for module.exports

### DIFF
--- a/moment-msdate.js
+++ b/moment-msdate.js
@@ -64,7 +64,7 @@
 		return nMsDate;
 	};
 
-	if ((typeof module !== 'undefined' && module !== null ? module.exports : undefined) !== null) {
+	if ((typeof module !== 'undefined' && module !== null ? module.exports : undefined) != null) {
 		module.exports = moment;
 	}
 


### PR DESCRIPTION
When running moment-msdate in the browser (and without require.js), the library works fine, but throws an exception on this block:

	if ((typeof module !== 'undefined' && module !== null ? module.exports : undefined) != null) {
		module.exports = moment;
	}

The exception reads:

    Uncaught ReferenceError: module is not defined
        at moment-msdate@0.2.0:68
        at moment-msdate@0.2.0:71

You can try this live in a simple HTML page here: <https://cdn.rawgit.com/Zlatkovsky/2f59c552505873f8fd73dc3657b1b9ed/raw/762f060aa5bedc9c044de9995fbfa13a39baa811/index.html>

The issue is that the if statement creates an `undefined` which it then compares with `!== null` and -- since the two don't match -- tries to set an `exports` property on an undefined `module` object.  Fix is to make the equality check be non-strict and skip the `module.exports = moment` line for *both* null and undefined, since it would fail in either case.

It appears that the issue is a regression introduced in January in commit https://github.com/markitondemand/moment-msdate/commit/4b4f712615e5bebdd5582c8262c07afa79ed7188.

Thanks!